### PR TITLE
Makefile: Replace `CMD=/bin/sh' with `CMD /bin/sh'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ all: mkimage-slackware.sh
 	for version in $(VERSIONS) ; do \
 		$(MAKE) $(RELEASENAME)-$${version}.tar && \
 		$(MAKE) VERSION=$${version} clean && \
-		$(CRT) import -c 'CMD=/bin/sh' $(RELEASENAME)-$${version}.tar $(USER)/$(NAME):$${version} && \
+		$(CRT) import -c 'CMD /bin/sh' $(RELEASENAME)-$${version}.tar $(USER)/$(NAME):$${version} && \
 		$(CRT) run -i --rm $(USER)/$(NAME):$${version} /usr/bin/echo "$(USER)/$(NAME):$${version} :: Success." ; \
 	done && \
 	$(CRT) tag $(USER)/$(NAME):$(LATEST) $(USER)/$(NAME):latest


### PR DESCRIPTION
Docker failed with CMD=bin/sh:

$ docker import -c 'CMD=/bin/sh' slackware64-14.2.tar user/slackware:14.2
Error response from daemon: cmd=/bin/sh is not a valid change command