### PR TITLE
Updated the image build to support 15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-LATEST		= 14.2
+LATEST		= 15.0
 VERSION		= $(LATEST)
-VERSIONS	= 13.0 13.1 13.37 14.0 14.1 14.2 current
+VERSIONS	= 13.0 13.1 13.37 14.0 14.1 14.2 15.0 current
 NAME		= slackware
 MIRROR		= http://slackware.osuosl.org
 ifeq ($(shell uname -m),x86_64)

--- a/mkimage-slackware.sh
+++ b/mkimage-slackware.sh
@@ -49,6 +49,10 @@ base_pkgs="a/aaa_base \
 	a/bin \
 	a/bzip2 \
 	a/grep \
+	a/acl \
+	l/pcre \
+	l/gmp \
+ 	a/attr \
 	a/sed \
 	a/dialog \
 	a/file \
@@ -126,7 +130,7 @@ fi
 # an update in upgradepkg during the 14.2 -> 15.0 cycle changed/broke this
 root_env=""
 root_flag="--root /mnt"
-if [ "$VERSION" = "current" ] ; then
+if [ "$VERSION" = "current" ] || [ "${VERSION}" = "15.0" ]; then
 	root_env='ROOT=/mnt'
 	root_flag=''
 fi


### PR DESCRIPTION
Slackware 15.0 has additional packages that are required. These
dependencies have been added to the mkimage-slackware.sh script. The
'make all' build target now includes 15.0.