### PR TITLE
Add elogind for 15.0 and current, libseccomp for current.

### DIFF
--- a/mkimage-slackware.sh
+++ b/mkimage-slackware.sh
@@ -67,6 +67,8 @@ base_pkgs="a/aaa_base \
 	a/utempter \
 	a/which \
 	a/util-linux \
+	a/elogind \
+	l/libseccomp \
 	l/mpfr \
 	l/libunistring \
 	ap/diffutils \


### PR DESCRIPTION
`ps` on 15.0 and current is linked to libelogind causing `ps` to be non-functional currently:

```sh
$ docker run --rm vbatts/slackware:14.2 ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.0   9232   840 ?        Rs   09:59   0:00 ps aux
$ docker run --rm vbatts/slackware:15.0 ps aux
ps: error while loading shared libraries: libelogind.so.0: cannot open shared object file: No such file or directory
$ docker run --rm vbatts/slackware:current ps aux
ps: error while loading shared libraries: libelogind.so.0: cannot open shared object file: No such file or directory
$ docker run --rm vbatts/slackware:current ldd /bin/ps
        linux-vdso.so.1 => linux-vdso.so.1 (0x00007fff767c7000)
        libprocps.so.8 => /lib64/libprocps.so.8 (0x00007f15012b2000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007f15012ad000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f15010b5000)
        /lib64/ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2 (0x00007f15012ee000)
        libelogind.so.0 => not found
```

On current, `more` (which is used by `slackpkg`), is linked to libseccomp, causing this to be broken in the current image:

```sh
$ docker run --rm vbatts/slackware:15.0 more /etc/slackware-version
::::::::::::::
/etc/slackware-version
::::::::::::::
Slackware 15.0
$ docker run --rm vbatts/slackware:current more /etc/slackware-version
more: error while loading shared libraries: libseccomp.so.2: cannot open shared object file: No such file or directory
```