### PR TITLE
correct slackpkg exit code typo

### DIFF
--- a/mkimage-slackware.sh
+++ b/mkimage-slackware.sh
@@ -191,7 +191,7 @@ fi
 mount --bind /etc/resolv.conf etc/resolv.conf
 
 # for slackware 15.0, slackpkg return codes are now:
-# 0 -> All OK, 1 -> something wrong, 20 -> empty list, 50 -> Slackpkg upgraded, 100 -> no pending updates
+# 0 -> All OK, 1 -> something wrong, 20 -> empty list, 50 -> Slackpkg upgraded, 100 -> There are pending updates
 chroot_slackpkg() {
 	PATH=/bin:/sbin:/usr/bin:/usr/sbin \
 	chroot . /bin/bash -c 'yes y | /usr/sbin/slackpkg -batch=on -default_answer=y update'


### PR DESCRIPTION
Correct the interpretation of status code one hundred to signal availability of updates, the opposite of what is written.

From slackpkg's man page:

```
EXIT STATUS

0 Successful slackpkg execution.
1 Something wrong happened.
20 No package found to be downloaded, installed, reinstalled, upgraded, or
removed.
50 Slackpkg itself was upgraded and you need to re-run it.
100 There are pending updates.
```